### PR TITLE
Removing hardcoded serverUrl from config.js, issue 7

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -1,8 +1,6 @@
 var SpkAppConfig = {
-  serverUrl: 'https://s003.speckle.works/api',
+  //serverUrl: 'https://s003.speckle.works/api'
   allowGuestAccess: true,
-  // serverUrl: 'https://server.speckle.works',
-  // logoUrl: 'dist/logo.png'
   logoUrl: 'https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-04-04/164468419442_9561f3ab8bcd823ebe33_132.png'
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -84,9 +84,9 @@ export default {
     }
   },
   created() {
+    window.SpkAppConfig.serverUrl = window.location.protocol + '//' + window.location.hostname + ':3000/api'
     this.$http.get( window.SpkAppConfig.serverUrl )
     .then( response => {
-      
 
       var account = localStorage.getItem('userAccount')
       var jwtToken = localStorage.getItem('userJwtToken')


### PR DESCRIPTION
Removed hardcoded serverUrl from config.js. Port (3000) is still hardcoded, now in App.vue, so this may cause problems if port for SpeckleServer varies