### PR TITLE
chore: updated readme to reflect current behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ More info to come.
 # install dependencies
 npm install
 
-# serve with hot reload at localhost:8888 (8080 is taken by the local speckle server instance 💯)
+# serve with hot reload at localhost:8080.
 npm run dev
 
 # build for production with minification
 npm run build
 ```
+
+## Running the client
+
+After running `npm run dev`, the client will start on localhost:8080.
+By default, the client will try to connect to the server on localhost:8080/api. However, this can be overridden using
+query parameters. For instance, to use the Speckle test server, go to:
+
+`localhost:8080?server=https://hestia.speckle.works`


### PR DESCRIPTION
1. I removed the comment on line 16, as it now seems inaccurate. The client starts at 8080, not 8888.
2. I added some information about how you can run the client with query parameters. Feel free to reformulate this, but I used quite some time to figure out how to connect to the test server, as I don't know Vue, so I figured this would be handy for others as well.